### PR TITLE
Add support for CM4 platform detection

### DIFF
--- a/src/protect-platform.ts
+++ b/src/protect-platform.ts
@@ -189,7 +189,7 @@ export class ProtectPlatform implements DynamicPlatformPlugin {
           const systemId = readFileSync("/sys/firmware/devicetree/base/model", { encoding: "utf8" });
 
           // Is it a Pi 4?
-          if(systemId.includes("Raspberry Pi 4")) {
+          if(systemId.includes("Raspberry Pi 4") || systemId.includes("Raspberry Pi Compute Module 4")) {
 
             this._hostSystem = "raspbian";
           }


### PR DESCRIPTION
Tested this patch out locally and enables hardware decoding by default on CM4s.

Closes https://github.com/hjdhjd/homebridge-unifi-protect/issues/965


With this patch, my logs now look like this:

```
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Office Door [UP Sense]: Enabled sensor: contact.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Georgia [G3 Flex]: Video streaming configured to use only: High.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Georgia [G3 Flex]: Hardware-accelerated decoding enabled.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Front Door [G4 Doorbell]: Video streaming configured to use only: High.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Front Door [G4 Doorbell]: Hardware-accelerated decoding enabled.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Driveway [G4 Instant]: Video streaming configured to use only: High.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Driveway [G4 Instant]: Hardware-accelerated decoding enabled.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Otto [G3 Flex]: Video streaming configured to use only: High.
[03/08/2023, 11:25:23] [UniFi Protect] BEC [UCK-G2-PLUS] Otto [G3 Flex]: Hardware-accelerated decoding enabled.
[03/08/2023, 11:25:24] [UniFi Protect] BEC [UCK-G2-PLUS] Yard [G3 Instant]: Video streaming configured to use only: High.
[03/08/2023, 11:25:24] [UniFi Protect] BEC [UCK-G2-PLUS] Yard [G3 Instant]: Hardware-accelerated decoding enabled.
```